### PR TITLE
Make CustomizeBuildings config easier to read for other mods, example included

### DIFF
--- a/src/CustomizeBuildings/Customize_Buildings_ModIntegration.cs
+++ b/src/CustomizeBuildings/Customize_Buildings_ModIntegration.cs
@@ -1,0 +1,78 @@
+﻿using HarmonyLib;
+using System;
+
+namespace CustomizeBuildings
+{
+    /// <summary>
+    /// This class can be copied by other mods to easily read values from the mod config of CustomizeBuildings
+    /// </summary>
+    public static class Customize_Buildings_ModIntegration
+    {
+        static object ConfigState = null;
+        public static bool IntegrationActive { get; private set; } = false;
+        static bool _initializationRun = false;
+
+        /// <summary>
+        /// Fetches a reference to the config state object to later read values from it
+        /// </summary>
+        public static void Init()
+        {
+            if (_initializationRun)
+                return;
+            _initializationRun = true;
+
+            ///fetch the config class type
+            var CustomizeBuildings_CustomizeBuildingsState = Type.GetType("CustomizeBuildings.CustomizeBuildingsState, CustomizeBuildings");
+            if (CustomizeBuildings_CustomizeBuildingsState == null)
+            {
+                Debug.Log("CustomizeBuildings types not found.");
+                return;
+            }
+            ///fetch the method info of the static getter method
+            var m_GetModConfigState = AccessTools.Method(CustomizeBuildings_CustomizeBuildingsState.GetType(), "GetModConfigState");
+            if (m_GetModConfigState == null)
+            {
+                Debug.LogWarning("CustomizeBuildings.CustomizeBuildingsState.GetModConfigState method not found.");
+                return;
+            }
+            ///fetch the mod config state object 
+            ConfigState = m_GetModConfigState.Invoke(null, null);
+            IntegrationActive = ConfigState != null;
+        }
+
+        /// <summary>
+        /// wrapper that allows fetching a config state value of type T
+        /// Can only reliably be called after all mods are loaded, e.g. during a non-transpiler patch
+        /// </summary>
+        /// <typeparam name="T">type of the property to fetch</typeparam>
+        /// <param name="propertyName">name of the property</param>
+        /// <param name="value">fetched value of the property. default(T) if not found or the types dont match</param>
+        /// <returns>bool if the property was found successfully</returns>
+        public static bool TryGetConfigValue<T>(string propertyName, out T value)
+        {
+            value = default(T);
+            Init();
+            if (!IntegrationActive)
+                return false;
+
+            Traverse property = Traverse.Create(ConfigState).Property(propertyName);
+            if (!property.PropertyExists())
+            {
+                Debug.LogWarning("Mod Config State did not have a property with the name: " + propertyName);
+                return false;
+
+            }
+            object propertyValue = property.GetValue();
+            var foundType = propertyValue.GetType();
+            var T_Type = typeof(T);
+            if (foundType != T_Type)
+            {
+                Debug.LogWarning("Mod Config State had a property with the name: " + propertyName + ", but it was typeOf " + foundType.Name + ", instead of the expected " + T_Type.Name);
+                return false;
+            }
+
+            value = (T)propertyValue;
+            return true;
+        }
+    }
+}

--- a/src/CustomizeBuildings/Customize_Buildings_ModIntegration.cs
+++ b/src/CustomizeBuildings/Customize_Buildings_ModIntegration.cs
@@ -42,7 +42,7 @@ namespace CustomizeBuildings
 
         /// <summary>
         /// wrapper that allows fetching a config state value of type T
-        /// Can only reliably be called after all mods are loaded, e.g. during a non-transpiler patch
+        /// Can only reliably be called after all mods are loaded, e.g. during a non-transpiler patch or in a building/entity definition method
         /// </summary>
         /// <typeparam name="T">type of the property to fetch</typeparam>
         /// <param name="propertyName">name of the property</param>

--- a/src/CustomizeBuildings/_CustomizeBuildingsState.cs
+++ b/src/CustomizeBuildings/_CustomizeBuildingsState.cs
@@ -6,7 +6,6 @@ using HarmonyLib;
 using PeterHan.PLib.Options;
 using System.IO;
 using System;
-using System.Diagnostics;
 
 namespace CustomizeBuildings
 {

--- a/src/CustomizeBuildings/_CustomizeBuildingsState.cs
+++ b/src/CustomizeBuildings/_CustomizeBuildingsState.cs
@@ -6,6 +6,7 @@ using HarmonyLib;
 using PeterHan.PLib.Options;
 using System.IO;
 using System;
+using System.Diagnostics;
 
 namespace CustomizeBuildings
 {
@@ -14,6 +15,16 @@ namespace CustomizeBuildings
     [ModInfo(null, collapse: true)]
     public class CustomizeBuildingsState : IManualConfig
     {
+        /// <summary>
+        /// static method that returns the current config state.
+        /// Makes it possible for other mods to easily reflect for the config state to read values.
+        /// </summary>
+        /// <returns></returns>
+        public static object GetModConfigState()
+        {
+            return StateManager.State;
+        }
+
         public int version { get; set; } = 59;
 
         #region $Reset Button


### PR DESCRIPTION
Adds a static method to the mod config of CustomizeBuildings.

this helps other mods to more easily read config values of the mod for better intra-mod compatibility.

the class `Customize_Buildings_ModIntegration` is an example of such an integration, it can be directly copied by other mods.

Those mods then can call `Customize_Buildings_ModIntegration.TryGetConfigValue` to read config state values without any further requirements