### PR TITLE
Fix MissingMethodException: SimMessages.SetCellProperties now takes callbackIdx

### DIFF
--- a/src/CustomizeBuildings/DoorSelfSealing.cs
+++ b/src/CustomizeBuildings/DoorSelfSealing.cs
@@ -95,7 +95,7 @@ namespace CustomizeBuildings
             {
                 int cell = cells[i];
                 World.Instance.groundRenderer.MarkDirty(cell);
-                SimMessages.SetCellProperties(cell, 4);
+                SimMessages.SetCellProperties(cell, 4, -1);
                 SimMessages.SetInsulation(cell, __instance.insulationModifier);
                 if (is_door_open)
                 {


### PR DESCRIPTION
## Problem

On the current ONI build, `Customize Buildings` throws on door state changes when **Door Self Sealing** is enabled:

```
System.MissingMethodException: Method not found: void SimMessages.SetCellProperties(int,byte)
  at DoorSelfSealing_Patch.Prefix (...)
  at Door.SetWorldState (...)
```

The game added a third parameter to the sim call:

| | Signature |
|---|---|
| Old | `SimMessages.SetCellProperties(int gameCell, byte properties)` |
| Current | `SimMessages.SetCellProperties(int gameCell, byte properties, int callbackIdx)` |

`DoorSelfSealing_Patch.Prefix` (`src/CustomizeBuildings/DoorSelfSealing.cs:98`) still calls the removed two-arg overload, so the prefix throws and the door's gas/liquid seal state never updates.

## Fix

Pass `callbackIdx: -1` (no callback), matching the sibling `SetInsulation` / `ReplaceAndDisplaceElement` calls in the same loop.

```diff
- SimMessages.SetCellProperties(cell, 4);
+ SimMessages.SetCellProperties(cell, 4, -1);
```

## Testing

Built a corrected copy and ran it in-game with Door Self Sealing enabled — doors seal/open without the exception. One-line change, no behavior change beyond resolving the call.